### PR TITLE
fix: Intel GPU Dockerfile Python 3.12 compatibility

### DIFF
--- a/Dockerfile.gpu-intel
+++ b/Dockerfile.gpu-intel
@@ -5,7 +5,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     python3 python3-pip python3-venv \
     libsndfile1 ffmpeg portaudio19-dev \
-    intel-opencl-icd intel-level-zero-gpu level-zero \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -u 1001 appuser && \
@@ -20,7 +19,8 @@ COPY --chown=appuser:appuser requirements.txt ./requirements.txt
 RUN python3 -m venv /app/venv
 ENV PATH="/app/venv/bin:$PATH"
 
-RUN pip3 install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu && \
+RUN pip3 install --no-cache-dir --upgrade pip setuptools wheel && \
+    pip3 install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu && \
     pip3 install --no-cache-dir -r requirements.txt
 
 COPY --chown=appuser:appuser . .

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ python-dotenv==1.0.0
 watchfiles==1.0.4
 
 # Audio Processing
-numpy==1.24.0
+numpy>=1.26.0
 sounddevice==0.4.6
 snac==1.2.1       # Required for audio generation from tokens
 

--- a/tts_engine/inference.py
+++ b/tts_engine/inference.py
@@ -667,7 +667,7 @@ def generate_speech_from_api(prompt, voice=DEFAULT_VOICE, output_file=None, temp
                      use_batching=True, max_batch_chars=1000):
     """Generate speech from text using Orpheus model with performance optimizations."""
     print(f"Starting speech generation for '{prompt[:50]}{'...' if len(prompt) > 50 else ''}'")
-    print(f"Using voice: {voice}, GPU acceleration: {'Yes (High-end)' if HIGH_END_GPU else 'Yes' if torch.cuda.is_available() else 'No'}")
+    print(f"Using voice: {voice}, GPU acceleration: {'Yes (High-end)' if HIGH_END_GPU else 'Yes' if is_gpu(device) else 'No'}")
     
     # Reset performance monitor
     global perf_monitor


### PR DESCRIPTION
## Problem

The `Dockerfile.gpu-intel` fails to build on the `intel/oneapi-runtime:latest` base image (Ubuntu Noble, Python 3.12) due to three issues:

### 1. Broken apt dependencies
`intel-level-zero-gpu` has unmet dependencies (`libigc1`, `libigdfcl1`) that are not installable. These packages (`intel-opencl-icd`, `intel-level-zero-gpu`, `level-zero`) are already present in the `intel/oneapi-runtime` base image.

### 2. Python 3.12 pkgutil.ImpImporter removal
`numpy==1.24.0` and old `setuptools` use `pkgutil.ImpImporter` which was [removed in Python 3.12](https://docs.python.org/3.12/whatsnew/3.12.html#removed). This causes:
```
AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
```

### 3. GPU acceleration display
`inference.py` checks `torch.cuda.is_available()` for the GPU acceleration log message, which returns `False` on Intel XPU even though the GPU is being used.

## Changes

- **Dockerfile.gpu-intel**: Remove redundant Intel GPU packages from apt install
- **Dockerfile.gpu-intel**: Add `pip install --upgrade pip setuptools wheel` before torch
- **requirements.txt**: Bump numpy from `==1.24.0` to `>=1.26.0`
- **tts_engine/inference.py**: Use `is_gpu(device)` instead of `torch.cuda.is_available()`

## Testing

Tested on Intel Arc B580 (12GB VRAM) running on Unraid 7.1.4:
- Docker image builds successfully ✅
- SNAC model loads on `xpu:0` ✅
- TTS generation produces valid 24kHz WAV audio ✅
- `device.py` detects Intel XPU correctly ✅
- llama.cpp SYCL inference: ~20 tok/s ✅